### PR TITLE
Change SPDX license entries to Apache-2.0

### DIFF
--- a/Jenkinsfiles/hydra_copy
+++ b/Jenkinsfiles/hydra_copy
@@ -1,7 +1,7 @@
 #!groovy
-// SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2022 Ville-Pekka Juntunen <ville-pekka.juntunen@unikie.com>
-// SPDX-FileCopyrightText: 2022 Unikie
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022-2023 Ville-Pekka Juntunen <ville-pekka.juntunen@unikie.com>
+// SPDX-FileCopyrightText: 2022-2023 Unikie
 
 resultsPath = '/home/tc-agent02/Jenkins-agent/workspace/results'
 imagesPath = '/home/tc-agent02/Jenkins-agent/workspace/images/'

--- a/Jenkinsfiles/post_processing_nuc
+++ b/Jenkinsfiles/post_processing_nuc
@@ -1,7 +1,7 @@
 #!groovy
-// SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2022 Ville-Pekka Juntunen <ville-pekka.juntunen@unikie.com>
-// SPDX-FileCopyrightText: 2022 Unikie
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022-2023 Ville-Pekka Juntunen <ville-pekka.juntunen@unikie.com>
+// SPDX-FileCopyrightText: 2022-2023 Unikie
 
 buildResults = [:]
 

--- a/addtimestamp/add_timestamp.py
+++ b/addtimestamp/add_timestamp.py
@@ -1,6 +1,6 @@
-# SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: 2022 Ville-Pekka Juntunen <ville-pekka.juntunen@unikie.com>
-# SPDX-FileCopyrightText: 2022 Unikie
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2022-2023 Ville-Pekka Juntunen <ville-pekka.juntunen@unikie.com>
+# SPDX-FileCopyrightText: 2022-2023 Unikie
 # ------------------------------------------------------------------------
 # Script for adding "Post processing done" unix timestamp to <buildID>.json.
 # ------------------------------------------------------------------------

--- a/hydracopy/hydra_copy.sh
+++ b/hydracopy/hydra_copy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: 2022 Ville-Pekka Juntunen <ville-pekka.juntunen@unikie.com>
-# SPDX-FileCopyrightText: 2022 Unikie
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2022-2023 Ville-Pekka Juntunen <ville-pekka.juntunen@unikie.com>
+# SPDX-FileCopyrightText: 2022-2023 Unikie
 # ------------------------------------------------------------------------
 # This script is used as "action" of hydrascraper.py and it will copy given Hydra build nix store from http://binarycache.vedenemo.dev
 # And it add Hydra build ID to working list if copy succeeded

--- a/hydractl/hydractl.py
+++ b/hydractl/hydractl.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env pipenv-shebang
 # ------------------------------------------------------------------------
-# SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: 2022 Tero Tervala <tero.tervala@unikie.com>
-# SPDX-FileCopyrightText: 2022 Unikie
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2022-2023 Tero Tervala <tero.tervala@unikie.com>
+# SPDX-FileCopyrightText: 2022-2023 Unikie
 # ------------------------------------------------------------------------
 # Script for adding a projects and a jobsets into Hydra
 

--- a/hydrascrape/hydrascrape.py
+++ b/hydrascrape/hydrascrape.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env pipenv-shebang
 # ------------------------------------------------------------------------
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2022-2023 Tero Tervala <tero.tervala@unikie.com>
 # SPDX-FileCopyrightText: 2022-2023 Unikie
 # ------------------------------------------------------------------------

--- a/indexer/indexer.py
+++ b/indexer/indexer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env pipenv-shebang
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2022-2023 Tero Tervala <tero.tervala@unikie.com>
 # SPDX-FileCopyrightText: 2022-2023 Unikie
 


### PR DESCRIPTION
Apache-2.0 is the correct license for code files.
Also updated copyright year markings.

Signed-off-by: Tero Tervala <tero.tervala@unikie.com>