### PR TITLE
hydra: Fix "Output limit exceeded"

### DIFF
--- a/containers/hydra/Dockerfile
+++ b/containers/hydra/Dockerfile
@@ -10,6 +10,7 @@ FROM nixos/nix
 RUN mkdir -p /setup/
 COPY channel.sh user.sh nix_conf.sh postgres.sh hydra.sh \
      populate.sh packages.lst upload.sh /setup/
+COPY hydra_conf.sh /setup/
 
 RUN chmod +x /setup/*.sh
 
@@ -23,7 +24,8 @@ ARG HYDRA_REMOTE_BUILDERS
 RUN nix-env -i hydra -i postgresql
 
 RUN /setup/user.sh "$HYDRA_UID" "$HYDRA_GID" && \
-    /setup/nix_conf.sh "$HYDRA_REMOTE_BUILDERS"
+    /setup/nix_conf.sh "$HYDRA_REMOTE_BUILDERS" && \
+    /setup/hydra_conf.sh
 
 RUN mkdir -p /run/postgresql && chmod go+w /run/postgresql
 COPY launch.sh run.sh /launch/

--- a/containers/hydra/hydra_conf.sh
+++ b/containers/hydra/hydra_conf.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2022-2023 Marko Lindqvist <marko.lindqvist@unikie.com>
+# SPDX-FileCopyrightText: 2022-2023 Unikie
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
+
+# This script runs during the container setup.
+
+# We have no sed to easily use template
+
+(
+  echo "max_output_size = 8589934393;"
+) > /setup/hydra.conf

--- a/containers/hydra/run.sh
+++ b/containers/hydra/run.sh
@@ -13,6 +13,7 @@ pg_ctl start -D /home/hydra/db
 # https://github.com/NixOS/hydra/issues/1186
 export LOGNAME="hydra"
 export HYDRA_DATA="/home/hydra/db"
+export HYDRA_CONFIG="/setup/hydra.conf"
 hydra-server &
 GC_DONT_GC="true" hydra-evaluator &
 hydra-queue-runner


### PR DESCRIPTION
Make it possible to fetch results size of the
final image from the remote builder.