### PR TITLE
action.py: Return nonzero if no postbuild info

### DIFF
--- a/hydrascrape/action.py
+++ b/hydrascrape/action.py
@@ -147,8 +147,9 @@ def main(argv: list[str]):
 
     jsonf = os.getenv("HYDRA_POSTBUILD_INFO")
     if jsonf == None:
-        # Return zero so this build will be marked as handled
-        perror("Warning: HYDRA_POSTBUILD_INFO not defined, ignoring old build", 0)
+        # Return nonzero so this build will be retried, this could happen if scraping was done at the exact
+        # time that other build info was available on Hydra, but runcommands were not finished yet.
+        perror("Error: HYDRA_POSTBUILD_INFO not defined")
 
     # Copy build info json file
     nix_copy(cacheurl, [jsonf])


### PR DESCRIPTION
There is a time frame when Hydra UI has other build information, but the postbuild script has not been run yet. After this change the processing the build will be retried on the next scraper run.

Earlier, a build without runcommand logs was assumed to be old one from the time before postbuild script, and thus it was just marked as handled one.

By now all the old builds should be already in the handled builds list, and we can assume all builds will have postbuild info eventually.