### PR TITLE
csvdiff: Add cols option

### DIFF
--- a/csvdiff/flake.lock
+++ b/csvdiff/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679944645,
-        "narHash": "sha256-e5Qyoe11UZjVfgRfwNoSU57ZeKuEmjYb77B9IVW7L/M=",
+        "lastModified": 1681303793,
+        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bb072f0a8b267613c127684e099a70e1f6ff106",
+        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
         "type": "github"
       },
       "original": {

--- a/csvdiff/setup.py
+++ b/csvdiff/setup.py
@@ -17,7 +17,7 @@ def project_path(*names):
     return os.path.join(os.path.dirname(__file__), *names)
 
 
-with open(project_path("VERSION")) as f:
+with open(project_path("VERSION"), encoding="utf-8") as f:
     version = f.read().strip()
 
 requires = [


### PR DESCRIPTION
- Add --cols command-line option to allow comparing the two CSV files based on a subset of column names.
- Use tempdir for tests.
- Update flake lock file.