### PR TITLE
csvdiff: Don't drop groupby columns

### DIFF
--- a/csvdiff/src/csvdiff.py
+++ b/csvdiff/src/csvdiff.py
@@ -172,6 +172,12 @@ def _csv_diff(path_left, path_right, ignoredups=False, cols=None):
         on=uids,
         suffixes=("_left", "_right"),
     )
+    if set(uids) != set(df_left.columns):
+        # Get back the dropped columns from df_left
+        df_diff = df_diff.merge(df_left, how="inner", on=uids)
+    if set(uids) != set(df_right.columns):
+        # Get back the dropped columns from df_right
+        df_diff = df_diff.merge(df_right, how="inner", on=uids, suffixes=("", "_right"))
     # Add column 'diff' that classifies the diff status
     df_diff["diff"] = df_diff.apply(_classify_row, axis=1)
     if LOG.level <= logging.DEBUG:

--- a/csvdiff/tests/test_csvdiff.py
+++ b/csvdiff/tests/test_csvdiff.py
@@ -150,7 +150,7 @@ def test_csvdiff_cols_dups():
     cmd = [CSVDIFF, left_path, right_path, "--cols=vuln_id,package"]
     ret = subprocess.run(cmd, check=False, capture_output=True, text=True)
     assert ret.returncode == 1
-    assert "LEFT_ONLY rows: 1" in ret.stderr
+    assert "LEFT_ONLY rows: 3" in ret.stderr
     # With --cols and --ignoredups
     cmd = [
         CSVDIFF,


### PR DESCRIPTION
- Don't drop columns that were not considered in diffing
- Fix relevant test case