### PR TITLE
hydra: Add support for /etc/hosts entries

### DIFF
--- a/containers/confs/hydra.default
+++ b/containers/confs/hydra.default
@@ -18,6 +18,10 @@ HYDRA_URL="localhost:${HC_PORT}"
 # If "yes", will use <store>/home/machines file, which then must be provided
 HC_REMOTE_BUILDERS=no
 
+# Entry to add to the container hosts file (for address resolution).
+# Currently can't contain multiple entries.
+#HC_CUSTOM_HOSTS="hostname:ip"
+
 if [ -f confs/hydra.local ] ; then
   # Possible overrides
   . confs/hydra.local

--- a/containers/run_hydra.sh
+++ b/containers/run_hydra.sh
@@ -147,17 +147,25 @@ fi
 
 echo "MOUNTS:" $MOUNTS
 
+if [ "$HC_CUSTOM_HOSTS" != "" ] ; then
+  HOSTS="--add-host=${HC_CUSTOM_HOSTS}"
+else
+  HOSTS=""
+fi
+
 if [ "$CONTAINER_DEBUG" = "true" ] ; then
   # Debug run
   docker run -i -p ${HC_PORT}:3000 \
-	 $PRIVILEGED \
-	 $MOUNTS \
-	 -e SETUP_RUN="ext" \
+         $PRIVILEGED \
+         $MOUNTS \
+         $HOSTS \
+         -e SETUP_RUN="ext" \
          -t "$HC_BASE_LABEL"
 else
   # Regular run
   docker run -i -p ${HC_PORT}:3000 \
-	 $PRIVILEGED \
+         $PRIVILEGED \
          $MOUNTS \
+         $HOSTS \
          -t "$HC_BASE_LABEL"
 fi


### PR DESCRIPTION
With a new configuration entry HC_CUSTOM_HOSTS, one custom hosts entry can be added for the container.