### PR TITLE
hydra: Run extracopy.sh every two minutes

### DIFF
--- a/containers/hydra/Dockerfile
+++ b/containers/hydra/Dockerfile
@@ -8,7 +8,7 @@ FROM nixos/nix
 RUN mkdir -p /setup/
 COPY channel.sh user.sh nix_conf.sh postgres.sh hydra.sh \
      populate.sh packages.lst upload.sh /setup/
-COPY hydra_conf.sh postbuild.py extracopy.sh /setup/
+COPY hydra_conf.sh postbuild.py extracopy.sh schedule.sh /setup/
 
 RUN chmod +x /setup/*.sh
 

--- a/containers/hydra/run.sh
+++ b/containers/hydra/run.sh
@@ -5,6 +5,8 @@
 
 # Normal container run - not the first run that does setup work instead.
 
+/setup/schedule.sh &
+
 pg_ctl start -D /home/hydra/db
 
 # GC_DONT_GC is needed for hydra-evaluator to work around

--- a/containers/hydra/schedule.sh
+++ b/containers/hydra/schedule.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+# Keep this script simple. We don't want THIS to die,
+# as then it would remain dead.
+while true ; do
+  sleep 120
+  /setup/extracopy.sh
+done


### PR DESCRIPTION
This makes build info generated on the postbuild hook to get uploaded to the cache, when container so configured.