### PR TITLE
Add support for Slack messaging

### DIFF
--- a/containers/README.hydra
+++ b/containers/README.hydra
@@ -53,3 +53,25 @@ and two latter ones are the private keys to establish the connection.
 
 Currently webserver upload is supported in setups where also binarycache
 upload has been activated.
+
+----
+
+Hydra supports messaging to Slack channel. One needs first to create new Slack app
+with write rights (https://api.slack.com/apps) and storing given auth token to safe
+private place. Then Slack app must be installed to Slack workspace and to channel to
+be used for build information messages.
+
+Configuration file slack_conf need to be created and stored manually to /store/home.
+File content need to be the following:
+line1: Secret Slack auth token
+line2: Name of the Slack channel to be messaged
+
+Messager.py implements actual message sending and it is defined to be the current messaging
+tool using env variable POSTBUILD_MSGSCRIPT in the run.sh (container booting code)
+
+
+
+
+
+
+

--- a/containers/hydra/Dockerfile
+++ b/containers/hydra/Dockerfile
@@ -8,9 +8,11 @@ FROM nixos/nix
 RUN mkdir -p /setup/
 COPY channel.sh user.sh nix_conf.sh postgres.sh hydra.sh \
      populate.sh packages.lst upload.sh /setup/
-COPY hydra_conf.sh postbuild.py extracopy.sh webcopy.sh schedule.sh /setup/
+COPY hydra_conf.sh postbuild.py extracopy.sh webcopy.sh schedule.sh messager.py /setup/
+
 
 RUN chmod +x /setup/*.sh
+RUN chmod +x /setup/messager.py
 
 ARG CHANNEL
 RUN /setup/channel.sh "$CHANNEL"

--- a/containers/hydra/messager.py
+++ b/containers/hydra/messager.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p "python3.withPackages(ps: [ ps.slackclient ])"
+#
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Hydra Slack messaging script
+#
+# Prints given message to configured Slack channel with major hydra build
+# information data
+#
+# Slack configuration file format:
+# line1: Slack auth secret token (given when Slack application created)
+# line2: Used Slack channel (Slack application must be installed for this channel for usage)
+#
+# Do not keep this auth file in version control system. Postbuild (user of this script) assumes
+# it is stored to store/home in host side.
+#
+#
+# ------------------------------------------------------------------------
+
+import os,sys,argparse
+import json
+import slack
+from slack import WebClient
+from slack.errors import SlackApiError
+
+
+__version__ = u"0.73300"
+MESSAGETEXT=u""
+
+
+parser = argparse.ArgumentParser(description="Send message to Slack channel (as a Slack app)",
+
+
+ epilog="""
+
+    Configuration file content: line0: slack app token, line1:slack channel to be messaged
+    Keep token (and configuration file) in safe. Do not store to git.
+
+    python3 messager.py  -m "TEXT FOR SLACKCHANNEL" -f CONFIGURATION FILE"""
+
+)
+parser.add_argument('-v', help='Send Slack message', action='version',version="Version:{0}   mika.nokka1@gmail.com ,  MIT licenced ".format(__version__) )
+parser.add_argument("-f",help='<Slack configuration file>',metavar="file")
+parser.add_argument("-m",help='<Slack message>',metavar="message")
+
+args = parser.parse_args()
+SLACKMESSAGE = args.m or ''
+SLACKCONFIGURATIONFILE= args.f or ''
+
+# quick old-school way to check needed parameters
+if (SLACKMESSAGE=='' or  SLACKCONFIGURATIONFILE=='' ):
+        print("\n---> MISSING ARGUMENTS!!\n ")
+        parser.print_help()
+        sys.exit(2)
+
+file_exists = os.path.exists(SLACKCONFIGURATIONFILE)
+
+if (file_exists):
+
+        SLACKMESSAGE="" # forming first message part here, not using passed argument
+
+        print ("Slack configuration file exists. Going to do the messaging",file=sys.stderr)
+        file = open(SLACKCONFIGURATIONFILE, "r")
+        config_array=file.read().split()
+        slackchannel=str(config_array[1])
+        slacktoken=str(config_array[0])
+
+        hydraserver = os.getenv("POSTBUILD_SERVER")
+        if hydraserver == None:
+            print ("No Hydra server defined",file=sys.stderr)
+            HYDRASERVER=""
+        else:
+            HYDRASERVER="\nHydra server:"+hydraserver
+
+        hydradata= os.getenv("HYDRA_JSON")
+        if hydradata == None:
+            print ("No Hydra JSON defined",file=sys.stderr)
+        else:
+            with open(hydradata) as jsonf:
+                binfo = json.load(jsonf)
+                #prettyinfo=json.dumps(binfo,indent=3)
+                buildjob=str(binfo['job'])
+                buildstatus=str(binfo['buildStatus'])
+                buildnumber=str(binfo['build'])
+                buildproject=str(binfo['project'])
+
+                if (int(buildstatus)==0):
+                    SLACKMESSAGE="OK Build !!!"
+
+                else:
+                    SLACKMESSAGE="Broken Build !!!"
+
+                SLACKMESSAGE=SLACKMESSAGE+HYDRASERVER+"\nHydra build:"+str(buildjob)+"\nStatus:"+buildstatus+"\nNumber:"+buildnumber+"\nProject:"+buildproject
+
+        try:
+            client = slack.WebClient(token=slacktoken)
+            client.chat_postMessage(channel=slackchannel, text=SLACKMESSAGE)
+
+        except Exception as e:
+            print(("Slacking failed! Check your channel name?, error: %s" % e))
+            sys.exit(1)
+
+
+else:
+        print ("No Slack configuration file found. Doing nothing",file=sys.stderr)

--- a/containers/hydra/run.sh
+++ b/containers/hydra/run.sh
@@ -14,6 +14,7 @@ pg_ctl start -D /home/hydra/db
 export LOGNAME="hydra"
 export HYDRA_DATA="/home/hydra/db"
 export HYDRA_CONFIG="/setup/hydra.conf"
+export POSTBUILD_MSGSCRIPT="/setup/messager.py -m nonews -f \"/home/hydra/slack_config\""
 hydra-server &
 GC_DONT_GC="true" hydra-evaluator &
 hydra-notify &


### PR DESCRIPTION
Build information send to Slack if configuration done. Activation requires slack_config file to exists in containers/store/home Content need to be 1) Slack secret auth token 2) Used Slack channel