### PR TITLE
hydra: Create ghaf-2023.05 project

### DIFF
--- a/containers/hydra/hydra-configure.sh
+++ b/containers/hydra/hydra-configure.sh
@@ -32,3 +32,10 @@ python3 "$HYDRACTL" \
         "$SERVER" AJ \
         -p ghaf -i ghaf -D ghaf \
         -t flake -f git+https://github.com/tiiuae/ghaf/
+
+python3 "$HYDRACTL" "$SERVER" AP -i ghaf-23-05 -D "Ghaf project 23.05"
+
+python3 "$HYDRACTL" \
+        "$SERVER" AJ \
+        -p ghaf-23-05 -i ghaf -D "Ghaf project 23.05" \
+        -t flake -f "git+https://github.com/tiiuae/ghaf/?ref=ghaf-23.05"


### PR DESCRIPTION
If hydra2 gets recreated, or a test environment matching it gets created, setup ghaf-2023.05 project there.