### PR TITLE
hydra: Support nixos-23.05 based ghaf

### DIFF
--- a/containers/hydra/packages.lst
+++ b/containers/hydra/packages.lst
@@ -27,3 +27,10 @@
 /nix/store/n47nsa09pban4cjhbcapm7a7lp7n1x5k-fira-code-6.2
 
 /nix/store/dqaik3rwbhrfjhmsrik1ja9g8dq5dy7y-fix-bug-80431.patch
+
+
+# ghaf nix-2023.05
+/nix/store/mdrv8znlgnysqzq1hnv46vi9jmnsc1bc-mpc-1.3.1.tar.gz
+/nix/store/v28dv6l0qk3j382kp40bksa1v6h7dx9p-bash-5.2.tar.gz
+/nix/store/zkas816mjrr8ijdj29qs4wqyn38l4j12-libunistring-1.1.tar.gz
+/nix/store/0avnvyc7pkcr4pjqws7hwpy87m6wlnjc-make-4.4.1.tar.gz


### PR DESCRIPTION
Update packages.lst to preinstall currently
unbuildable source packages.