### PR TITLE
Use #!/usr/bin/env bash shebang

### DIFF
--- a/containers/run_bcache.sh
+++ b/containers/run_bcache.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0

--- a/containers/run_hydra.sh
+++ b/containers/run_hydra.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0

--- a/containers/run_jenkins_agent.sh
+++ b/containers/run_jenkins_agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0

--- a/containers/run_jenkins_controller.sh
+++ b/containers/run_jenkins_controller.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
`#!/bin/bash` does not work on NixOS systems. Use `#!/usr/bin/env bash` for compatibility across all platforms.