### PR TITLE
Include hydra buildinfo as-is in the provenance

### DIFF
--- a/provenance/provenance.py
+++ b/provenance/provenance.py
@@ -131,11 +131,11 @@ def generate_provenance(
                 "externalParameters": {},
                 "internalParameters": {
                     "server": post_build["Server"],
-                    "system": post_build["System"],
-                    "jobset": post_build["Jobset"],
                     "project": post_build["Project"],
+                    "jobset": post_build["Jobset"],
                     "job": post_build["Job"],
                     "drvPath": post_build["Derivation store path"],
+                    "system": post_build["System"],
                 },
                 "resolvedDependencies": resolve_build_dependencies(sbom_path),
             },
@@ -156,6 +156,7 @@ def generate_provenance(
                 "byproducts": list_byproducts(resultsdir),
             },
         },
+        "hydra_buildInfo": build_info
     }
 
     with open(


### PR DESCRIPTION
Just appends the buildinfo as-is into the provenance as an extension field https://slsa.dev/provenance/v1#extension-fields

Not very useful before provenance is moved to hydra, as provenance is the last step of our jenkins pipeline.