### PR TITLE
extracopy.sh: Use batch mode for sftp and scp

### DIFF
--- a/containers/hydra/extracopy.sh
+++ b/containers/hydra/extracopy.sh
@@ -115,7 +115,9 @@ function Sftp_mkdir_cmd {
 
     # Echo mkdir and cd for each directory
     for dir in "${patharr[@]}"; do
-        echo "mkdir ${dir}"
+        # mkdir may fail if directory exists, thus dash prefix
+        echo "-mkdir ${dir}"
+        # chdir may not fail, thus no dash prefix
         echo "cd ${dir}"
     done
 
@@ -239,9 +241,9 @@ trap On_exit EXIT
                 # Also remove image postfix to get the target name
                 TGT="${TGT%"$EC_IMGPSTFX"}"
                 DIR="images/${THISSRV}/${TGT}/"
-                date "+%H:%M:%S Creating directory /upload/${DIR}"
-                Sftp_mkdir_cmd "/upload/${DIR}" | sftp -i "$EC_SFTPKEYFIL" "${EC_SFTPUSER}@${WEBSRV}" > /dev/null 2>&1
-                if scp -s -i "$EC_SFTPKEYFIL" "$FULL" "${EC_SFTPUSER}@${WEBSRV}:/upload/${DIR}"; then
+                date "+%H:%M:%S Creating directory /upload/${DIR} (Remote mkdir failures are expected for existing directories)"
+                Sftp_mkdir_cmd "/upload/${DIR}" | sftp -b - -i "$EC_SFTPKEYFIL" "${EC_SFTPUSER}@${WEB_SERVER}" > /dev/null
+                if scp -B -s -i "$EC_SFTPKEYFIL" "$FULL" "${EC_SFTPUSER}@${WEB_SERVER}:/upload/${DIR}"; then
                     date "+%H:%M:%S Running trigger for ${FILE}"
                     ssh -n -i "$EC_TRIGKEYFIL" "${EC_TRIGUSER}@${WEBSRV}" -- "--sha256 ${DIR}${FILE}"
                 else


### PR DESCRIPTION
Now if e.g. host is not in known_hosts you'll get an error, instead of any interactive prompts. (Preferred action in a cron job)