### PR TITLE
hydra: Support package signing

### DIFF
--- a/containers/README.hydra
+++ b/containers/README.hydra
@@ -58,7 +58,19 @@ persistent storage.
   WEB_TRIG_USER, WEB_TRIG_KEY_FILE and optiobally WEB_PROTO, WEB_PORT and WEB_SSH_PORT.
   Please see example-webserver.conf for details
 
-----
+ ----
+
+Hydra can sign packages it builds.
+
+Currently this needs to be set up by placing files to
+persistent storage.
+
+- home/confs/signing.conf should be a shell fragment
+  setting environment variables SIGNING_SRV, SIGNING_SRV_KEY_FILE,
+  SIGNING_SRV_PATH, SIGNING_SRV_USER, and optionally SIGNING_PORT.
+  Please see example-signing.conf for details.
+
+ ----
 
 Hydra supports messaging to Slack channel. One needs first to create new Slack app
 with write rights (https://api.slack.com/apps) and storing given auth token to safe
@@ -73,8 +85,7 @@ line2: Name of the Slack channel to be messaged
 Messager.py implements actual message sending and it is defined to be the current messaging
 tool using env variable POSTBUILD_MSGSCRIPT in the run.sh (container booting code)
 
-
-----
+ ----
 
 Hydra store versions:
 

--- a/containers/hydra/Dockerfile
+++ b/containers/hydra/Dockerfile
@@ -7,7 +7,7 @@ FROM nixos/nix
 
 RUN mkdir -p /setup/
 COPY channel.sh user.sh nix_conf.sh postgres.sh hydra.sh \
-     populate.sh packages.lst upload.sh /setup/
+     populate.sh packages.lst pbhook.sh upload.sh sign.sh /setup/
 COPY hydra_conf.sh postbuild.py extracopy.sh schedule.sh messager.py /setup/
 
 

--- a/containers/hydra/example-signing.conf
+++ b/containers/hydra/example-signing.conf
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+# Hydra container configuration for signing server
+
+# SIGNING_SRV optional parameter, if unset or empty, signing is disabled
+SIGNING_SRV=""
+
+# SIGNING_SRV_USER optional parameter, if unset or empty, signing is disabled
+# username on signing server
+SIGNING_SRV_USER="hydra"
+
+# SIGNING_SRV_PATH optional parameter, if unset or empty, signing is disabled
+# Path to the signing script directory on signing server
+SIGNING_SRV_PATH="/home/hydra"
+
+# SIGNING_SRV_KEY_FILE mandatory parameter
+# SSH key file to access signing server
+SIGNING_SRV_KEY_FILE="/home/hydra/.ssh/sign_srv.key"
+
+# SIGNING_PORT optional parameter
+# Signing server ssh port (default "22")
+#SIGNING_PORT="2222"

--- a/containers/hydra/nix_conf.sh
+++ b/containers/hydra/nix_conf.sh
@@ -34,7 +34,7 @@ else
 fi
 
 nix_conf_line "allowed-uris" "https://github.com/ https://source.codeaurora.org/"
-nix_conf_line "post-build-hook" "/setup/upload.sh"
+nix_conf_line "post-build-hook" "/setup/pbhook.sh"
 nix_conf_line "system-features" "nixos-test benchmark big-parallel kvm"
 nix_conf_line "experimental-features" "nix-command flakes"
 

--- a/containers/hydra/pbhook.sh
+++ b/containers/hydra/pbhook.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+# Callback script called after a package has been built
+
+/setup/sign.sh
+/setup/upload.sh

--- a/containers/hydra/sign.sh
+++ b/containers/hydra/sign.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+
+# Callback script called after a package has been built
+
+if [ -f /home/hydra/confs/signing.conf ] ; then
+  . /home/hydra/confs/signing.conf
+  if [ -n "$SIGNING_SRV" ] && [ -n "$SIGNING_SRV_KEY_FILE" ] &&
+     [ -n "$SIGNING_SRV_PATH" ] && [ -n "$SIGNING_SRV_USER" ] ; then
+    if [ -n "$SIGNING_PORT" ] ; then
+      export SIGN_SSHOPTS="-i $SIGNING_SRV_KEY_FILE -l $SIGNING_SRV_USER -p $SIGNING_PORT"
+    else
+      export SIGN_SSHOPTS="-i $SIGNING_SRV_KEY_FILE -l $SIGNING_SRV_USER"
+    fi
+
+    SIGNTMPDIR="/home/hydra/signatures"
+    mkdir -p "${SIGNTMPDIR}"
+
+    for PTH in $OUT_PATHS $DRV_PATH
+    do
+      SHA256SUM="$(sha256sum $PTH)"
+      SIGNATURE_FILE="${SIGNTMPDIR}/$(basename "${PTH}").signature"
+
+      ssh $SIGN_SSHOPTS "$SIGNING_SRV" "${SIGNING_SRV_PATH}/start.sh" \
+	  --sign "--h=${SHA256SUM}" | tail -n 1 > "${SIGNATURE_FILE}"
+      nix-store --add "${SIGNATURE_FILE}"
+
+      # Remove temporary
+      rm -f "${SIGNATURE_FILE}"
+    done
+  fi
+fi


### PR DESCRIPTION
Just create a signature file, to see that signing functionality is there. This exact form is unlikely to be used as the final way to transfer the singature.