### PR TITLE
Generate provenance in hydra container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+containers/store

--- a/containers/hydra/Dockerfile
+++ b/containers/hydra/Dockerfile
@@ -35,6 +35,11 @@ RUN chmod +x /launch/*.sh
 RUN chown -R hydra:hydra /nix/var/nix
 RUN rm -Rf /root/.cache
 
+# install sbomnix
+COPY install-sbomnix.sh /setup/
+RUN chmod +x /setup/install-sbomnix.sh
+RUN /setup/install-sbomnix.sh
+
 # copy all other setup scripts that will be used later
 COPY postgres.sh hydra.sh populate.sh packages.lst postbuild.py extracopy.sh \ 
     schedule.sh messager.py provenance.sh provenance.py \

--- a/containers/hydra/Dockerfile
+++ b/containers/hydra/Dockerfile
@@ -6,25 +6,25 @@
 FROM nixos/nix
 
 RUN mkdir -p /setup/
-COPY channel.sh user.sh nix_conf.sh postgres.sh hydra.sh \
-     populate.sh packages.lst pbhook.sh upload.sh sign.sh /setup/
-COPY hydra_conf.sh postbuild.py extracopy.sh schedule.sh messager.py /setup/
 
-
-RUN chmod +x /setup/*.sh
-RUN chmod +x /setup/messager.py
-
+# nix channel setup
 ARG CHANNEL
+COPY channel.sh /setup/
+RUN chmod +x /setup/channel.sh
 RUN /setup/channel.sh "$CHANNEL"
 
+# install nix packages
+RUN nix-env -i hydra -i postgresql -i jq -i gnused -i python3
+
+# setup users and hydra
 ARG HYDRA_UID
 ARG HYDRA_GID
 ARG HYDRA_REMOTE_BUILDERS
 ARG PB_SRV
 ARG HYDRA_URL
 
-RUN nix-env -i hydra -i postgresql -i jq -i gnused
-
+COPY user.sh nix_conf.sh hydra_conf.sh upload.sh pbhook.sh sign.sh /setup/
+RUN chmod +x /setup/*.sh
 RUN /setup/user.sh "$HYDRA_UID" "$HYDRA_GID" && \
     /setup/nix_conf.sh "$HYDRA_REMOTE_BUILDERS" && \
     /setup/hydra_conf.sh "$PB_SRV" "$HYDRA_URL"
@@ -34,6 +34,15 @@ COPY launch.sh run.sh /launch/
 RUN chmod +x /launch/*.sh
 RUN chown -R hydra:hydra /nix/var/nix
 RUN rm -Rf /root/.cache
+
+# copy all other setup scripts that will be used later
+COPY postgres.sh hydra.sh populate.sh packages.lst postbuild.py extracopy.sh \ 
+    schedule.sh messager.py provenance.sh provenance.py \
+    /setup/
+
+# make sure everything is executable
+RUN chmod +x /setup/*.sh
+RUN chmod +x /setup/messager.py
 
 ARG CONTAINER_DEBUG=false
 RUN touch /etc/container-debug-${CONTAINER_DEBUG}

--- a/containers/hydra/hydra_conf.sh
+++ b/containers/hydra/hydra_conf.sh
@@ -17,7 +17,4 @@
   echo "using_frontend_proxy = 1"
 ) > /setup/hydra.conf
 
-# Install python3 that the postbuild.py will need when used
-nix-env -i python3
-
 echo "${1}" > /setup/postbuildsrv.txt

--- a/containers/hydra/install-sbomnix.sh
+++ b/containers/hydra/install-sbomnix.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+COMMIT_HASH=3916a93e0bb694215a86b3b251bfa02344dc40d1
+
+git clone https://github.com/tiiuae/sbomnix
+cd sbomnix || exit
+git checkout "$COMMIT_HASH"
+
+env NIX_PROFILE=/nix/var/nix/profiles/default nix-env -f default.nix --install

--- a/containers/hydra/provenance.py
+++ b/containers/hydra/provenance.py
@@ -1,0 +1,209 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+
+"""Script for generating SLSA compliant provenance file from hydra postbuild"""
+
+import argparse
+import glob
+import json
+import os
+import subprocess
+from datetime import datetime
+from typing import Optional
+
+BUILD_TYPE_DOCUMENT = "TODO"
+BUILD_ID_DOCUMENT = "TODO"
+
+
+def run_command(cmd: list[str], **kwargs):
+    """Run shell command as subprocess and get the stdout as string"""
+    with subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        **kwargs,
+    ) as proc:
+        out, _err = proc.communicate()
+        return out.decode().strip()
+
+
+def nix_hash(image: str):
+    """Get sha256 hash of nix store item"""
+    return run_command(["nix-hash", "--base32", "--type", "sha256", image])
+
+
+def parse_subjects(products: list[dict]) -> list[dict]:
+    """Parse the given product path for image files
+    and return them as ResourceDescriptors"""
+    # TODO: use imagePath instead of products for this
+    subjects = []
+    for product in products:
+        output_store = product["path"]
+        if os.path.exists(output_store):
+            subjects += [
+                {
+                    "name": file,
+                    "uri": f"{output_store}/{file}",
+                    "digest": {
+                        "sha256": nix_hash(f"{output_store}/{file}"),
+                    },
+                }
+                for file in os.listdir(output_store)
+            ]
+        else:
+            # built image is not available, create best effort subject
+            subjects.append({"uri": output_store})
+
+    return subjects
+
+
+def resolve_build_dependencies(sbom_path: str | None):
+    """Parse the sbom for dependencies
+    and return them as ResourceDescriptors"""
+    if sbom_path is None:
+        return []
+
+    try:
+        with open(sbom_path, "rb") as file:
+            sbom = json.load(file)
+    except FileNotFoundError as e:
+        print(e)
+        return []
+
+    return [
+        {
+            "name": component["name"],
+            "uri": component["bom-ref"],
+        }
+        for component in sbom["components"]
+    ]
+
+
+def list_byproducts(resultsdir: str | None):
+    """Generate ResourceDescriptor for each file in the result directory
+    as these files can be classified as byproducts of the build"""
+    if resultsdir is None:
+        return []
+
+    return [
+        {
+            "name": file.rsplit("/")[-1],
+            "uri": file,
+        }
+        for file in glob.glob(resultsdir + "/*", recursive=True)
+    ]
+
+
+def builder_git_rev(workspace: str | None):
+    """Get git remote url and current commit hash of the build system"""
+    # TODO: make this use git commit id provided by container build
+    if workspace is None:
+        return []
+
+    url = run_command(
+        ["git", "remote", "get-url", "origin"],
+        cwd=workspace,
+    )
+    commit_hash = run_command(
+        ["git", "rev-parse", "HEAD"],
+        cwd=workspace,
+    )
+
+    return [
+        {
+            "uri": url,
+            "digest": {
+                "gitCommit": commit_hash,
+            },
+        }
+    ]
+
+
+def generate_provenance(
+    build_info_path: str,
+    byproduct_dir: str,
+    sbom_path: Optional[str],
+    builder_workspace: Optional[str],
+):
+    """Generate the provenance file from given inputs"""
+    with open(build_info_path, "rb") as file:
+        build_info = json.load(file)
+
+    build_id = build_info["build"]
+    schema = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": parse_subjects(build_info["products"]),
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "predicate": {
+            "buildDefinition": {
+                "buildType": BUILD_TYPE_DOCUMENT,
+                "externalParameters": {},
+                "internalParameters": {
+                    "system": build_info["system"],
+                    "jobset": build_info["jobset"],
+                    "project": build_info["project"],
+                    "job": build_info["job"],
+                    "drvPath": build_info["drvPath"],
+                },
+                "resolvedDependencies": resolve_build_dependencies(sbom_path),
+            },
+            "runDetails": {
+                "builder": {
+                    "id": BUILD_ID_DOCUMENT,
+                    "builderDependencies": builder_git_rev(builder_workspace),
+                },
+                "metadata": {
+                    "invocationId": build_id,
+                    "startedOn": datetime.fromtimestamp(
+                        build_info["startTime"],
+                    ).isoformat(),
+                    "finishedOn": datetime.fromtimestamp(
+                        build_info["stopTime"],
+                    ).isoformat(),
+                },
+                "byproducts": list_byproducts(byproduct_dir),
+            },
+        },
+        "hydra_buildInfo": build_info
+    }
+
+    return schema
+
+
+def main():
+    """Main function that parses the given arguments"""
+    parser = argparse.ArgumentParser(
+        prog="Provenance Converter",
+        description="Convert hydra build_info into provenance SLSA 1.0",
+    )
+    parser.add_argument("build_info")
+    parser.add_argument("--sbom")
+    parser.add_argument("--byproduct-dir")
+    parser.add_argument("--output-dir")
+    parser.add_argument("--builder-workspace")
+    args = parser.parse_args()
+    schema = generate_provenance(
+        args.build_info,
+        args.byproduct_dir,
+        args.sbom,
+        args.builder_workspace,
+    )
+
+    build_id = schema["predicate"]["runDetails"]["metadata"]["invocationId"]
+    outpath = ""
+    if args.output_dir:
+        outpath = args.output_dir
+        if not args.output_dir.endswith("/"):
+            outpath += "/"
+
+    with open(
+        f"{outpath}slsa_provenance_{build_id}.json",
+        "w",
+        encoding="utf=8",
+    ) as file:
+        file.write(json.dumps(schema, indent=4))
+
+
+if __name__ == "__main__":
+    main()

--- a/containers/hydra/provenance.sh
+++ b/containers/hydra/provenance.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+set -x
+
+IMAGE=$1
+BUILDINFO=$2
+BUILD_ID=$(jq -r '.build' "$BUILDINFO")
+OUTPUT_DIR="/home/hydra/results/$BUILD_ID"
+
+echo "PROVENANCE FOR BUILD $BUILD_ID"
+
+# create output dir in hydra home
+mkdir -p "$OUTPUT_DIR"
+cd "$OUTPUT_DIR" || exit
+
+# generate buildtime sbom
+sbomnix "$IMAGE" --type=buildtime --depth=1
+
+# generate the provenance file
+python3 /setup/provenance.py "$BUILDINFO" \
+	--output-dir "$OUTPUT_DIR" \
+	--sbom sbom.cdx.json
+
+# clean up sbom files
+# they are no longer needed
+rm sbom*


### PR DESCRIPTION
- sbomnix gets installed during the container build
- postbuild.py runs provenance.sh, which in turn runs sbomnix and provenance.py
- the resulting provenance file is located in `/home/hydra/results/$BUILD_ID/`

I also reorganized the dockerfile commands so it doesn't have to rebuild the whole container when one (insignificant) file is changed, but instead can use the docker cache effectively.