### PR TITLE
Enhance sha256tree with some options

### DIFF
--- a/sha256tree/sha256tree.py
+++ b/sha256tree/sha256tree.py
@@ -13,11 +13,27 @@ import stat
 DEBUG = False
 # Encoding for strings to be hashed
 ENCOD = 'UTF-8'
-# Buffer size to use when calculating file hashes
-BUFSIZ = 1024*1024
 
 
-def sha256sum(path) -> str | None:
+def show_help():
+    """Show usage help and exit"""
+
+    print(f"Usage: {sys.argv[0]} [options] [PATH1] [PATH2] ...")
+    print()
+    print("  PATHn = Paths to calculate sha256 hash for")
+    print()
+    print("Options:")
+    print("             -- = Use to separate from paths possibly starting with '--'")
+    print("        --plain = Just print the hash without entry type or basename")
+    print("         --help = Show this usage help")
+    print("        --debug = Enable printing of intermediate hashes to stderr")
+    print("  --buffer=SIZE = Set buffer size to be used when calculating hash for files")
+    print("                  (default: 1048576 bytes)")
+    print("")
+    sys.exit(0)
+
+
+def sha256sum(path, buf_size, hashonly=False) -> str | None:
     """CalculateS a sha256 checksum for a given path"""
 
     ptype = '-'
@@ -35,7 +51,7 @@ def sha256sum(path) -> str | None:
         dlist: list = os.listdir(path)
         dlist.sort()
         for item in dlist:
-            sha = sha256sum(os.path.join(path, item))
+            sha = sha256sum(os.path.join(path, item), buf_size)
             if sha is not None:
                 hsh.update(sha.encode(ENCOD))
         ptype = 'd'
@@ -67,7 +83,7 @@ def sha256sum(path) -> str | None:
     # It's a regular file, hash the contents
     elif stat.S_ISREG(fstat.st_mode):
         with open(path, "rb") as file:
-            while block := file.read(BUFSIZ):
+            while block := file.read(buf_size):
                 hsh.update(block)
 
     # It's something else, ignore with warning
@@ -76,15 +92,52 @@ def sha256sum(path) -> str | None:
             f"Warning: Unknown type ({hex(fstat.st_mode)}): {path}", file=sys.stderr)
         return None
 
-    res = hsh.hexdigest() + f" {ptype} " + os.path.basename(path) + "\n"
+    if hashonly:
+        res = hsh.hexdigest() + "\n"
+    else:
+        res = hsh.hexdigest() + f" {ptype} " + os.path.basename(path) + "\n"
+
     if DEBUG:
         print(res, end="", file=sys.stderr)
     return res
 
 
+def main(args: list[str]):
+    """Process options and then call sha256sum for rest of arguments"""
+
+    plain = False
+    bufsiz = 1024*1024
+    args.pop(0)
+
+    while args and args[0].startswith("--"):
+        if args[0] == "--":
+            args.pop(0)
+            break
+        if args[0] == "--plain":
+            plain = True
+        elif args[0] == "--help":
+            show_help()
+        elif args[0] == "--debug":
+            global DEBUG  # pylint: disable=global-statement
+            DEBUG = True
+        elif args[0].startswith("--buffer="):
+            args[0] = args[0].removeprefix("--buffer=")
+            bufsiz = int(args[0])
+            if bufsiz <= 0:
+                print(f"Invalid buffer size: {bufsiz}", file=sys.stderr)
+                sys.exit(1)
+        else:
+            print(f"Invalid argument: {args[0]}", file=sys.stderr)
+            sys.exit(1)
+
+        args.pop(0)
+
+    for arg in args:
+        print(sha256sum(arg, bufsiz, hashonly=plain), end="")
+
+
 # ------------------------------------------------------------------------
-# If this was invoked directly from command line, run sha256sum for each arg
+# If this was invoked directly from command line, run main function
 # ------------------------------------------------------------------------
 if __name__ == "__main__":
-    for arg in sys.argv[1:]:
-        print(sha256sum(arg), end="")
+    main(sys.argv[:])


### PR DESCRIPTION
Usage help is available.
Debug can be enabled on command line.
Buffer size can be set.
Plain mode for getting just the hash, no need for 'cutting' the output to get just the hash in another script.