### PR TITLE
Generate BuilderId and server name for provenance

### DIFF
--- a/containers/confs/hydra.default
+++ b/containers/confs/hydra.default
@@ -22,7 +22,7 @@ HC_PB_SRV="hydra"
 HC_STORE_PATH="./store"
 
 # URL of the Hydra instance
-HYDRA_URL="localhost:${HC_PORT}"
+HYDRA_URL="http://localhost:${HC_PORT}"
 
 # If "no",  build only locally.
 # If "yes", will use <store>/home/confs/machines file, which then must be provided

--- a/containers/hydra/provenance.sh
+++ b/containers/hydra/provenance.sh
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
+set -e
+
 # inputs
 IMAGE=$1
 BUILDINFO=$2
@@ -16,6 +18,8 @@ cd "$OUTPUT_DIR" || exit
 
 # generate buildtime sbom (and suppress noisy stdout)
 sbomnix "$IMAGE" --type=buildtime --depth=1 > /dev/null 2>&1
+
+. $HOME/setup_config
 
 # generate the provenance file
 /setup/provenance.py "$BUILDINFO" \

--- a/containers/run_hydra.sh
+++ b/containers/run_hydra.sh
@@ -177,6 +177,11 @@ do
  HOSTS+="--add-host=$host "
 done
 
+echo "# these are config values copied from setup
+export HYDRA_URL="$HYDRA_URL"
+export HYDRA_NAME="$HC_PB_SRV"
+" > "${STORE}/home/setup_config"
+
 if [ "$CONTAINER_DEBUG" = "true" ] ; then
   # Debug run
   docker run \


### PR DESCRIPTION
Adds ability to save some env variables from confs, so they can be read from within the container. Builder ID is constructed from HYDRA_URL config value, which is set to publicly available url such as `https://hydra2.vedenemo.dev/` in production. This also makes server name available in internalParameters.