### PR TITLE
Update sbomnix to the latest version

### DIFF
--- a/containers/hydra/install-sbomnix.sh
+++ b/containers/hydra/install-sbomnix.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
-COMMIT_HASH=3916a93e0bb694215a86b3b251bfa02344dc40d1
+COMMIT_HASH=055bf464f1a3344870a40f337caa492a69f69dbb
 
 git clone https://github.com/tiiuae/sbomnix
 cd sbomnix || exit


### PR DESCRIPTION
Simply updates the sbomnix hash in hydra container to point to latest version. Tested to have no effect on provenance but we might as well use the latest one.