### PR TITLE
Refactor provenance generation to a separate file

### DIFF
--- a/containers/hydra/provenance.py
+++ b/containers/hydra/provenance.py
@@ -34,6 +34,7 @@ def hydra_api(server: str, path: str) -> dict | None:
     response = requests.get(
         server + path,
         headers={"Content-Type": "application/json"},
+        timeout=30,
     )
     if response.status_code == 200:
         return response.json()

--- a/containers/hydra/run.sh
+++ b/containers/hydra/run.sh
@@ -14,7 +14,8 @@ pg_ctl start -D /home/hydra/db
 export LOGNAME="hydra"
 export HYDRA_DATA="/home/hydra/db"
 export HYDRA_CONFIG="/setup/hydra.conf"
-export POSTBUILD_MSGSCRIPT="/setup/messager.py -m nonews -f \"/home/hydra/confs/slack.config\""
+export POSTBUILD_MSGSCRIPT="/setup/messager.py -m nonews -f /home/hydra/confs/slack.conf"
+export POSTBUILD_PROVENANCE_SCRIPT="/setup/provenance.sh"
 hydra-server &
 GC_DONT_GC="true" hydra-evaluator &
 hydra-notify &


### PR DESCRIPTION
Provenance script is now modular and self contained like slack messaging is. 
- Set in run.sh with `POSTBUILD_PROVENANCE_SCRIPT`.
- Can be run on it's own without depending on postbuild.py
- Reads hydra information from env variables.