### PR TITLE
Docker tagging, using latest stale 2.17.0 as Hydra base image

### DIFF
--- a/containers/hydra/Dockerfile
+++ b/containers/hydra/Dockerfile
@@ -3,7 +3,7 @@
 
 # Container for the hydra
 
-FROM nixos/nix
+FROM nixos/nix:2.17.0
 
 RUN mkdir -p /setup/
 


### PR DESCRIPTION
Build test behaves as the "latest 2.18.0 based Nix image"