### PR TITLE
Upload build outputs separately to cache

### DIFF
--- a/containers/hydra/postbuild.py
+++ b/containers/hydra/postbuild.py
@@ -45,13 +45,15 @@ def perror(txt, code=1):
 
 
 # ------------------------------------------------------------------------
-def run_script(script: str) -> int:
+def run_script(script: str, exit_on_fail: bool = False) -> int:
     """Run given script"""
     ret = 0
     if script is not None:
         ret = os.system(script)
         if ret != 0:
             print(f"{script} failed: {ret}", file=sys.stderr)
+            if exit_on_fail:
+                sys.exit(1)
     return ret
 
 
@@ -79,6 +81,9 @@ def main():
 
     if outp is None:
         perror("Output not found")
+
+    # copy output and derivation to the cache
+    run_script(f"/setup/upload.sh {outp} {binfo['drvPath']}", exit_on_fail=True)
 
     run_script(PROVENANCE_SCRIPT)
     run_script(PACKAGE_SCRIPT)


### PR DESCRIPTION
after some investigation, I have found out `pbhook.sh` is not even being run on the final build output images (at least not all of them). This was an oversight that was never properly tested.

This change makes postbuild upload any outputs and derivations that are missing. Yes, it can still fail, but that will fail the whole RunCommand and it will be a visible failure. 

More reliable periodically scanning uploader with retry functionality might be developed in the future to replace this.