### PR TITLE
Enable HW tests to risc-v builds

### DIFF
--- a/Jenkinsfiles/hydra_copy
+++ b/Jenkinsfiles/hydra_copy
@@ -127,9 +127,9 @@ pipeline {
                                     [$class: 'StringParameterValue', name: 'server', value: "${params.server}"],
                                     [$class: 'StringParameterValue', name: 'project', value: "${buildData['Project']}"],
                                     [$class: 'BooleanParameterValue', name: 'development', value: params.development],
-                                    [$class: 'BooleanParameterValue', name: 'hw_tests', value: false],
+                                    [$class: 'BooleanParameterValue', name: 'hw_tests', value: true],
                                     [$class: 'StringParameterValue', name: 'label', value: "${params.label}"],
-                                    [$class: 'StringParameterValue', name: 'device', value: "risc-v"],
+                                    [$class: 'StringParameterValue', name: 'device', value: "riscv"],
                                     [$class: 'BooleanParameterValue', name: 'upload', value: params.upload]
                                 ]
                             } catch (err) {


### PR DESCRIPTION
Enable HW test to risc-v builds to run HW tests
on Polarfire.