### PR TITLE
hotfix: Handled_builds in nonexistant directory

### DIFF
--- a/Jenkinsfiles/hydra_copy
+++ b/Jenkinsfiles/hydra_copy
@@ -39,7 +39,7 @@ pipeline {
             }
             steps {
                 script {
-                    sh "python3 hydrascrape/hydrascrape.py ${params.server}.vedenemo.dev ${params.project} ${params.jobset} ${params.server}.vedenemo.dev/handled_builds "+ '\'python3 hydrascrape/action.py\''
+                    sh "python3 hydrascrape/hydrascrape.py ${params.server}.vedenemo.dev ${params.project} ${params.jobset} handled_builds_${params.server} "+ '\'python3 hydrascrape/action.py\''
                 }
             }
         }


### PR DESCRIPTION
fixes hydra_copy job when the server directory is not created yet.