### PR TITLE
Add config option to restart container on reboot

### DIFF
--- a/containers/confs/hydra.default
+++ b/containers/confs/hydra.default
@@ -33,6 +33,10 @@ HC_REMOTE_BUILDERS=no
 # if "yes", allow use of substitutes
 HC_SUBSTITUTES=no
 
+# If "no",  container is not restarted on reboot
+# if "yes", the container restart policy is set to 'always'
+HC_CONTAINER_RESTART=no
+
 # Entries to add to the container hosts file (for address resolution).
 declare -a HC_CUSTOM_HOSTS
 #HC_CUSTOM_HOSTS=("hostname1:ip1" "hostname2:ip2")

--- a/containers/run_hydra.sh
+++ b/containers/run_hydra.sh
@@ -218,6 +218,11 @@ if [ -t 0 ] && [ -t 1 ]; then
     EXTRA_FLAGS+=" -i"
 fi
 
+# set restart policy if configured
+if [ "${HC_RESTART_CONTAINER}" == "yes" ]; then
+    EXTRA_FLAGS+=" --restart always"
+fi
+
 # Regular run
 # shellcheck disable=SC2086 # EXTRA_FLAGS, MOUNTS and HOSTS purposefully unquoted
 docker run \


### PR DESCRIPTION
Adds hydra config option `HC_RESTART_CONTAINER` which when set to "yes" adds `--restart always` to the container flags.

Using restart policy `unless-stopped` was not sufficient as the container exits with error code 255 when the host machine is rebooted, causing it to not actually restart.